### PR TITLE
Fix SIGFPE in GameGridFrame when gamesPerRow is 0

### DIFF
--- a/src/qt_gui/game_grid_frame.cpp
+++ b/src/qt_gui/game_grid_frame.cpp
@@ -93,13 +93,18 @@ void GameGridFrame::PopulateGameGrid(QVector<GameInfo> m_games_search, bool from
     m_games_shared = std::make_shared<QVector<GameInfo>>(m_games_);
     icon_size = Config::getIconSizeGrid(); // update icon size for resize event.
 
-    int gamesPerRow = windowWidth / (icon_size + 20); // 2 x cell widget border size.
+    int gamesPerRow = (icon_size + 20 > 0) ? windowWidth / (icon_size + 20) : 1;
+    if (gamesPerRow <= 0)
+        gamesPerRow = 1; // Prevent division by zero
+
     int row = 0;
     int gameCounter = 0;
+
     int rowCount = m_games_.size() / gamesPerRow;
     if (m_games_.size() % gamesPerRow != 0) {
         rowCount += 1; // Add an extra row for the remainder
     }
+
 
     int column = 0;
     this->setColumnCount(gamesPerRow);


### PR DESCRIPTION
This patch fixes a crash (SIGFPE) that occurs in the method `GameGridFrame::PopulateGameGrid`.

The issue is caused by a division by zero when the variable `gamesPerRow` is calculated as 0 due to the `windowWidth` being smaller than `icon_size + 20`.

A fallback value of 1 is now used when `gamesPerRow` would be zero, preventing the division by zero and crash.

Fixes #8
